### PR TITLE
Enable keyboard navigation for header menu

### DIFF
--- a/Frontend/src/widgets/header/ui/header.jsx
+++ b/Frontend/src/widgets/header/ui/header.jsx
@@ -16,9 +16,19 @@ export default function Header() {
       className={styles.header}
       onMouseEnter={() => setMoonState(true)}
       onMouseLeave={() => setMoonState(false)}
+      onFocus={() => setMoonState(true)}
+      onBlur={(e) => {
+        if (!e.currentTarget.contains(e.relatedTarget)) {
+          setMoonState(false);
+        }
+      }}
       >
-      <div className={`${styles.moon} ${moonState ? styles.paused : ''}`}>
-      </div>
+      <button
+        type="button"
+        className={`${styles.moon} ${moonState ? styles.paused : ''}`}
+        aria-expanded={moonState}
+        aria-label="Toggle navigation"
+      />
       <div className={`${styles.menu} ${moonState ? styles.open : ''}`}>
         <ul className={styles.menuList}>
           {items.map(({label, to}) => (

--- a/Frontend/src/widgets/header/ui/header.module.css
+++ b/Frontend/src/widgets/header/ui/header.module.css
@@ -37,7 +37,10 @@ body {
     height: 8rem;
     background: #000;
     border-radius: 50%;
-    position: relative;    
+    position: relative;
+    border: none;
+    padding: 0;
+    cursor: pointer;
 }
 
 .moon::after {


### PR DESCRIPTION
## Summary
- Allow header menu to open when keyboard focus enters it
- Style moon control as a real button for accessibility

## Testing
- `npm test`
- `npm run lint` *(fails: Key "valid-jsdoc": Could not find "valid-jsdoc" in plugin "@".)*

------
https://chatgpt.com/codex/tasks/task_e_6895486bf58c8327bc7bff38599ee966